### PR TITLE
Improve bun validate CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can also pipe directly from another command:
 bun extract | bun validate
 ```
 
+If no file or piped data is provided, `bun validate` exits with an error.
+
 ---
 
 ## 🛠️ Output Format

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -3,7 +3,15 @@ import Ajv2020 from "ajv/dist/2020";
 import schema from "../../resources/ir.schema.json" assert { type: "json" };
 
 export function runValidate(file?: string) {
-  const input = file && file !== "-" ? readFileSync(file, "utf-8") : readFileSync(0, "utf-8");
+  const useStdin = !file || file === "-";
+
+  if (useStdin && process.stdin.isTTY) {
+    console.error("No input provided");
+    process.exit(1);
+  }
+
+  const input =
+    useStdin ? readFileSync(0, "utf-8") : readFileSync(file!, "utf-8");
   const json = JSON.parse(input);
   const ajv = new Ajv2020({ allErrors: true });
   const validate = ajv.compile(schema);


### PR DESCRIPTION
## Summary
- check for TTY when validating
- document validation error in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run validate` *(fails: tsx not found)*
- `bun run validate` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423603d2348329a04bad3e4e726cfa