### PR TITLE
Fix IR validation in runEmit

### DIFF
--- a/src/cli/emit.ts
+++ b/src/cli/emit.ts
@@ -20,9 +20,10 @@ export async function runEmit(language: string, options: { irFile?: string, outp
     irData = { ...ir, __extends__: extendsMap };
   }
 
-  const isValid = validateIR(irData);
-  if (!isValid) {
+  const { valid, errors } = validateIR(irData);
+  if (!valid) {
     console.error("❌ IR is invalid. Aborting emit.");
+    console.error(errors);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- check the validity flag when validating IR before emitting bindings

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module fs and other typings)*
- `bun install` *(fails: 403 errors fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847819224fc8329851c8b4502067a9a