### PR TITLE
Add workflow for publishing Gleam bindings

### DIFF
--- a/.github/workflows/publish-bindings.yaml
+++ b/.github/workflows/publish-bindings.yaml
@@ -1,0 +1,57 @@
+name: Publish Gleam Bindings
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'bindings-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Emit Gleam bindings
+        run: bun run emit
+
+      - name: Create gleam.toml
+        run: |
+          cat <<'TOML' > bindings/gleam/twig/gleam.toml
+          name = "twig"
+          version = "0.1.0"
+          description = "DOM bindings generated from WebIR"
+          licences = ["EPL-2.0"]
+          repository = "https://github.com/transpiler-dev/webir"
+          target = "javascript"
+
+          [dependencies]
+          gleam_stdlib = "~> 0.33"
+          TOML
+
+      - name: Set up Gleam
+        uses: gleam-lang/setup-gleam@v1
+
+      - name: Format and build package
+        run: |
+          cd bindings/gleam/twig
+          gleam format
+          gleam build
+
+      - name: Publish to Hex.pm
+        env:
+          HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
+        run: |
+          cd bindings/gleam/twig
+          gleam publish --yes


### PR DESCRIPTION
## Summary
- add workflow to publish generated Gleam bindings to Hex.pm

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a70f30483298768ec29ec357f6a